### PR TITLE
Fix Vive Wands & scrolling VR settings

### DIFF
--- a/Plugin.cs
+++ b/Plugin.cs
@@ -133,36 +133,52 @@ namespace TarkovVR
                         ETrackedDeviceClass deviceClass = system.GetTrackedDeviceClass(deviceIndex);
                         if (deviceClass == ETrackedDeviceClass.Controller)
                         {
-                            // Get controller type
+                            // Use a large buffer — some model strings exceed 64 chars
                             ETrackedPropertyError error = new ETrackedPropertyError();
-                            StringBuilder modelNumber = new StringBuilder(64);
-                            system.GetStringTrackedDeviceProperty(deviceIndex, ETrackedDeviceProperty.Prop_ModelNumber_String, modelNumber, 64, ref error);
+                            StringBuilder modelNumber = new StringBuilder(256);
+                            system.GetStringTrackedDeviceProperty(deviceIndex, ETrackedDeviceProperty.Prop_ModelNumber_String, modelNumber, 256, ref error);
+
+                            // Also read the render model name as a fallback identifier
+                            StringBuilder renderModel = new StringBuilder(256);
+                            system.GetStringTrackedDeviceProperty(deviceIndex, ETrackedDeviceProperty.Prop_RenderModelName_String, renderModel, 256, ref error);
+
+                            string modelStr = modelNumber.ToString();
+                            string renderStr = renderModel.ToString();
+                            Plugin.MyLog.LogInfo($"[Controller Detection] Device {deviceIndex}: ModelNumber='{modelStr}' RenderModel='{renderStr}'");
+
+                            // Case-insensitive matching — real strings seen in the wild:
+                            //   "VIVE Controller Pro MV", "VIVE Controller MV", "vive_controller"
+                            string modelLower = modelStr.ToLowerInvariant();
+                            string renderLower = renderStr.ToLowerInvariant();
 
                             string controllerType = "Unknown";
-                            if (modelNumber.ToString().Contains("Vive Controller"))
+                            if (modelLower.Contains("vive") || renderLower.Contains("vive_controller") || renderLower.Contains("vr_controller_vive"))
                             {
-                                VRGlobals.vrControllerType = "vive";
+                                // Only set once — don't overwrite a confirmed type with Unknown
+                                if (VRGlobals.vrControllerType != "vive")
+                                    VRGlobals.vrControllerType = "vive";
                                 controllerType = "Vive Wand";
                             }
-                            else if (modelNumber.ToString().Contains("Knuckles"))
+                            else if (modelLower.Contains("knuckles") || renderLower.Contains("knuckles"))
                             {
-                                VRGlobals.vrControllerType = "index";
+                                if (string.IsNullOrEmpty(VRGlobals.vrControllerType))
+                                    VRGlobals.vrControllerType = "index";
                                 controllerType = "Valve Index Knuckles";
                             }
-                            else if (modelNumber.ToString().Contains("Oculus Touch"))
+                            else if (modelLower.Contains("oculus touch") || renderLower.Contains("oculus"))
                             {
-                                VRGlobals.vrControllerType = "oculus";
+                                if (string.IsNullOrEmpty(VRGlobals.vrControllerType))
+                                    VRGlobals.vrControllerType = "oculus";
                                 controllerType = "Oculus Touch";
                             }
 
-                            Plugin.MyLog.LogInfo($"[Controller Detection] Found controller ({deviceIndex}): {modelNumber} ({controllerType})");
-
-                            // Log controller role (left/right)
                             ETrackedControllerRole role = system.GetControllerRoleForTrackedDeviceIndex(deviceIndex);
-                            Plugin.MyLog.LogInfo($"[Controller Detection] Controller role: {role}");
+                            Plugin.MyLog.LogInfo($"[Controller Detection] Found controller ({deviceIndex}): {modelStr} → type='{controllerType}', role={role}");
                         }
                     }
                 }
+
+                Plugin.MyLog.LogInfo($"[Controller Detection] Final vrControllerType='{VRGlobals.vrControllerType ?? "null"}'");
             }
             catch (Exception ex)
             {

--- a/Source/Controls/InputHandlers.cs
+++ b/Source/Controls/InputHandlers.cs
@@ -1,4 +1,4 @@
-﻿using EFT;
+using EFT;
 using EFT.InputSystem;
 using EFT.InventoryLogic;
 using EFT.UI;
@@ -31,40 +31,128 @@ namespace TarkovVR.Source.Controls
         }
 
         //------------------------------------------------------------------------------------------------------------------------------------------------------------
+        // Vive-friendly JumpInputHandler (v2):
+        //   Uses a PHYSICAL CLICK of the right trackpad as the trigger (binary, no sweet-spot).
+        //   The click is only accepted when the finger rests in the UPPER HALF of the pad (y > 0)
+        //   at the moment the click fires, so that clicking DOWN for crouch never accidentally jumps.
+        //   Short click  → Jump
+        //   Hold click   → Vault  (threshold configurable via VRSettings.GetVaultHoldTime())
+        //   Crouch threshold for CrouchHandler also uses VRSettings.GetCrouchThreshold().
         public class JumpInputHandler : IInputHandler
         {
-            private bool isVaulting = false;
-            private float timeHeld = 0f;
-            private static float TIME_HELD_FOR_VAULT = 0.3f;
+            private enum JumpState { Idle, Held, Fired }
+            private JumpState _state = JumpState.Idle;
+            private float _heldTime = 0f;
+
+            // Y > 0 means finger is in the upper half of the Vive trackpad disc.
+            // We use a small positive guard (0.05) to avoid the dead-centre triggering vault+jump.
+            private const float UPPER_HALF_Y = 0.05f;
+
             public void UpdateCommand(ref ECommand command)
             {
                 // Safety checks
-                if (VRGlobals.vrPlayer == null || SteamVR_Actions._default?.RightJoystick == null)
+                if (VRGlobals.vrPlayer == null ||
+                    SteamVR_Actions._default?.RightJoystick == null ||
+                    SteamVR_Actions._default?.ClickRightJoystick == null)
                     return;
 
+                if (VRGlobals.vrControllerType == "vive")
+                {
+                    UpdateVive(ref command);
+                }
+                else
+                {
+                    UpdateDefault(ref command);
+                }
+            }
+
+            // Vive Wand: physical trackpad click + upper-half guard
+            private void UpdateVive(ref ECommand command)
+            {
+                // Physical click state (binary, no sweet-spot on Vive)
+                bool clickHeld = SteamVR_Actions._default.ClickRightJoystick.GetState(SteamVR_Input_Sources.RightHand);
+                bool clickDown = SteamVR_Actions._default.ClickRightJoystick.GetStateDown(SteamVR_Input_Sources.RightHand);
+
+                // Touch position — used only as a guard to separate "jump/vault" from "crouch"
+                float fingerY = SteamVR_Actions._default.RightJoystick.GetAxis(SteamVR_Input_Sources.Any).y;
+                bool fingerInUpperHalf = fingerY > UPPER_HALF_Y;
+
+                command = ECommand.None;
+
+                switch (_state)
+                {
+                    case JumpState.Idle:
+                        if (clickDown && fingerInUpperHalf && !VRGlobals.vrPlayer.blockJump)
+                        {
+                            _state = JumpState.Held;
+                            _heldTime = 0f;
+                        }
+                        break;
+
+                    case JumpState.Held:
+                        if (!clickHeld)
+                        {
+                            // Released before vault threshold → Jump
+                            command = ECommand.Jump;
+                            _state = JumpState.Idle;
+                        }
+                        else
+                        {
+                            _heldTime += Time.deltaTime;
+                            if (_heldTime >= VRSettings.GetVaultHoldTime())
+                            {
+                                command = ECommand.Vaulting;
+                                _state = JumpState.Fired;
+                            }
+                        }
+                        break;
+
+                    case JumpState.Fired:
+                        if (!clickHeld)
+                        {
+                            // Send VaultingEnd if the player is still in vaulting state
+                            if (VRGlobals.player != null && VRGlobals.player.IsVaultingPressed)
+                                command = ECommand.VaultingEnd;
+                            _state = JumpState.Idle;
+                        }
+                        else
+                        {
+                            command = ECommand.Vaulting;
+                        }
+                        break;
+                }
+            }
+
+            // Default (Index, Oculus, etc.): original joystick axis logic
+            private bool _isVaulting = false;
+            private float _timeHeld = 0f;
+            private const float TIME_HELD_FOR_VAULT = 0.3f;
+
+            private void UpdateDefault(ref ECommand command)
+            {
                 float yAxis = SteamVR_Actions._default.RightJoystick.GetAxis(SteamVR_Input_Sources.Any).y;
 
                 if (!VRGlobals.vrPlayer.blockJump && yAxis > 0.925f)
                 {
-                    timeHeld += Time.deltaTime;
-                    if (timeHeld >= TIME_HELD_FOR_VAULT)
+                    _timeHeld += Time.deltaTime;
+                    if (_timeHeld >= TIME_HELD_FOR_VAULT)
                     {
                         command = ECommand.Vaulting;
-                        isVaulting = true;
+                        _isVaulting = true;
                     }
                 }
                 else
                 {
                     if (VRGlobals.player && VRGlobals.player.IsVaultingPressed)
                     {
-                        isVaulting = false;
+                        _isVaulting = false;
                         command = ECommand.VaultingEnd;
                     }
-                    else if (timeHeld > 0.05f && timeHeld < TIME_HELD_FOR_VAULT)
+                    else if (_timeHeld > 0.05f && _timeHeld < TIME_HELD_FOR_VAULT)
                     {
                         command = ECommand.Jump;
                     }
-                    timeHeld = 0f;
+                    _timeHeld = 0f;
                 }
             }
         }
@@ -86,9 +174,10 @@ namespace TarkovVR.Source.Controls
                     return;
 
                 float joystickY = SteamVR_Actions._default.RightJoystick.axis.y;
+                float crouchThreshold = VRSettings.GetCrouchThreshold();
 
                 // When the right joystick is pulled down, lower player pose (crouch)
-                if (joystickY < -0.8f)
+                if (joystickY < -crouchThreshold)
                 {
                     float poseDelta = -1.5f * Time.deltaTime;
                     VRGlobals.player.ChangePose(poseDelta);
@@ -99,7 +188,7 @@ namespace TarkovVR.Source.Controls
                 }
 
                 // When the joystick is pushed up and player has crouched, raise pose (stand)
-                if (VRGlobals.vrPlayer.crouchHeightDiff > 0.01f && joystickY > 0.8f)
+                if (VRGlobals.vrPlayer.crouchHeightDiff > 0.01f && joystickY > crouchThreshold)
                 {
                     float poseDelta = 0.05f;
                     VRGlobals.player.ChangePose(poseDelta);
@@ -131,12 +220,14 @@ namespace TarkovVR.Source.Controls
                 if (VRGlobals.player is HideoutPlayer || VRGlobals.blockRightJoystick)
                     return;
 
-                if (SteamVR_Actions._default.RightJoystick.axis.y > -0.8 && ((float)Math.Round(VRGlobals.vrPlayer.crouchHeightDiff, 1) == MAX_CROUCH_HEIGHT_DIFF))
+                float crouchThreshold = VRSettings.GetCrouchThreshold();
+
+                if (SteamVR_Actions._default.RightJoystick.axis.y > -crouchThreshold && ((float)Math.Round(VRGlobals.vrPlayer.crouchHeightDiff, 1) == MAX_CROUCH_HEIGHT_DIFF))
                     releasedPullAfterFullCrouch = true;
                 else if (releasedPullAfterFullCrouch && (float)Math.Round(VRGlobals.vrPlayer.crouchHeightDiff, 1) != MAX_CROUCH_HEIGHT_DIFF)
                     releasedPullAfterFullCrouch = false;
 
-                if (SteamVR_Actions._default.RightJoystick.axis.y < -0.8 && releasedPullAfterFullCrouch && Time.time - timeSinceLastPress > MIN_TIME_BETWEEN_PRESSES)
+                if (SteamVR_Actions._default.RightJoystick.axis.y < -crouchThreshold && releasedPullAfterFullCrouch && Time.time - timeSinceLastPress > MIN_TIME_BETWEEN_PRESSES)
                 {
                     releasedPullAfterFullCrouch = false;
                     command = ECommand.ToggleProne;

--- a/Source/Controls/InputHandlers.cs
+++ b/Source/Controls/InputHandlers.cs
@@ -37,7 +37,6 @@ namespace TarkovVR.Source.Controls
         //   at the moment the click fires, so that clicking DOWN for crouch never accidentally jumps.
         //   Short click  → Jump
         //   Hold click   → Vault  (threshold configurable via VRSettings.GetVaultHoldTime())
-        //   Crouch threshold for CrouchHandler also uses VRSettings.GetCrouchThreshold().
         public class JumpInputHandler : IInputHandler
         {
             private enum JumpState { Idle, Held, Fired }
@@ -174,8 +173,9 @@ namespace TarkovVR.Source.Controls
                     return;
 
                 float joystickY = SteamVR_Actions._default.RightJoystick.axis.y;
-                float crouchThreshold = VRSettings.GetCrouchThreshold();
-
+                float crouchThreshold = VRGlobals.vrControllerType == "vive"
+                    ? VRSettings.GetCrouchThreshold()
+                    : 0.8f;
                 // When the right joystick is pulled down, lower player pose (crouch)
                 if (joystickY < -crouchThreshold)
                 {
@@ -220,8 +220,9 @@ namespace TarkovVR.Source.Controls
                 if (VRGlobals.player is HideoutPlayer || VRGlobals.blockRightJoystick)
                     return;
 
-                float crouchThreshold = VRSettings.GetCrouchThreshold();
-
+                float crouchThreshold = VRGlobals.vrControllerType == "vive"
+                    ? VRSettings.GetCrouchThreshold()
+                    : 0.8f;
                 if (SteamVR_Actions._default.RightJoystick.axis.y > -crouchThreshold && ((float)Math.Round(VRGlobals.vrPlayer.crouchHeightDiff, 1) == MAX_CROUCH_HEIGHT_DIFF))
                     releasedPullAfterFullCrouch = true;
                 else if (releasedPullAfterFullCrouch && (float)Math.Round(VRGlobals.vrPlayer.crouchHeightDiff, 1) != MAX_CROUCH_HEIGHT_DIFF)

--- a/Source/Settings/VRSettings.cs
+++ b/Source/Settings/VRSettings.cs
@@ -488,56 +488,119 @@ namespace TarkovVR.Source.Settings
             frusCullingToggle.Text.localizationKey = "Disable Frustum Culling ";
             frusCullingToggle.Toggle.UpdateValue(settings.disableFrusCulling);
             */
-            //SetupScrollbar(vrSettings);
+            SetupScrollbar(vrSettings);
 
             vrSettingsObject = newSoundSettings.gameObject;
             UnityEngine.Object.Destroy(newSoundSettings);
         }
 
+        private static ScrollRect _vrSettingsScroll;
+
         private static void SetupScrollbar(GameObject vrSettings)
         {
-            // Find or add ScrollRect component
-            var scrollRect = vrSettings.GetComponentInChildren<ScrollRect>();
+            SoundSettingsTab tab = vrSettings.GetComponent<SoundSettingsTab>();
+            Transform slidersPanel = tab._slidersSection;
+            Transform panel = slidersPanel.parent;
+            RectTransform panelRT = panel.GetComponent<RectTransform>();
 
-            if (scrollRect == null)
-            {
-                // If no ScrollRect exists, we need to find the content parent and set it up
-                // The slidersPanel should be inside a viewport that has a ScrollRect
-                Transform viewport = null;
+            // Screen.height / scaleFactor gives the true Canvas-space height —
+            // rect.height on a stretch-anchored object returns the offset, not the real size.
+            Canvas canvas = vrSettings.GetComponentInParent<Canvas>();
+            float scaleFactor = (canvas != null && canvas.scaleFactor > 0f) ? canvas.scaleFactor : 1f;
+            float viewportHeight = Screen.height / scaleFactor - 70f;
 
-                // Try to find the viewport by looking for a common structure
-                // Usually it's: Settings -> Viewport -> Content (slidersPanel)
-                var soundSettings = settingsUi._soundSettingsScreen;
-                if (soundSettings != null)
-                {
-                    // Look for the parent of the sliders section which should be inside a viewport
-                    Transform contentParent = soundSettings._slidersSection.parent;
-                    if (contentParent != null)
-                    {
-                        viewport = contentParent.parent;
-                        if (viewport != null)
-                        {
-                            scrollRect = viewport.GetComponent<ScrollRect>();
-                        }
-                    }
-                }
-            }
+            // Destroy ContentSizeFitter so end-of-frame layout rebuild can't override our size
+            ContentSizeFitter panelCsf = panel.GetComponent<ContentSizeFitter>();
+            if (panelCsf != null)
+                UnityEngine.Object.Destroy(panelCsf);
 
-            // If we found or can access a ScrollRect, enable and configure it
-            if (scrollRect != null)
-            {
-                scrollRect.enabled = true;
-                scrollRect.vertical = true;
-                scrollRect.horizontal = false;
-                scrollRect.movementType = ScrollRect.MovementType.Clamped;
-                scrollRect.scrollSensitivity = 20f;
+            panelRT.sizeDelta = new Vector2(panelRT.sizeDelta.x, viewportHeight);
 
-                // Make sure the scrollbar is visible if it exists
-                if (scrollRect.verticalScrollbar != null)
-                {
-                    scrollRect.verticalScrollbar.gameObject.SetActive(true);
-                }
-            }
+            // Padding so first and last elements aren't clipped by the mask
+            VerticalLayoutGroup sliderVlg = slidersPanel.GetComponent<VerticalLayoutGroup>();
+            if (sliderVlg != null)
+                sliderVlg.padding = new RectOffset(
+                    sliderVlg.padding.left,
+                    sliderVlg.padding.right,
+                    40,
+                    40);
+
+            LayoutRebuilder.ForceRebuildLayoutImmediate(panelRT);
+
+            // RectMask2D clips content without affecting child layout
+            if (panel.GetComponent<RectMask2D>() == null)
+                panel.gameObject.AddComponent<RectMask2D>();
+
+            // SlidersSection as scroll content: anchor top-stretch, grow downward
+            RectTransform contentRT = slidersPanel.GetComponent<RectTransform>();
+            contentRT.anchorMin = new Vector2(0f, 1f);
+            contentRT.anchorMax = new Vector2(1f, 1f);
+            contentRT.pivot = new Vector2(0.5f, 1f);
+            contentRT.anchoredPosition = Vector2.zero;
+            contentRT.sizeDelta = new Vector2(0f, contentRT.sizeDelta.y);
+
+            ContentSizeFitter csf = slidersPanel.GetComponent<ContentSizeFitter>()
+                                    ?? slidersPanel.gameObject.AddComponent<ContentSizeFitter>();
+            csf.verticalFit = ContentSizeFitter.FitMode.PreferredSize;
+            csf.horizontalFit = ContentSizeFitter.FitMode.Unconstrained;
+
+            // ScrollRectNoDrag: responds only to scroll events from VRUIInteracter,
+            // never auto-scrolls to focused children (unlike ScrollRect)
+            ScrollRectNoDrag scrollRect = panel.GetComponent<ScrollRectNoDrag>()
+                                          ?? panel.gameObject.AddComponent<ScrollRectNoDrag>();
+            scrollRect.content = contentRT;
+            scrollRect.viewport = panelRT;
+            scrollRect.vertical = true;
+            scrollRect.horizontal = false;
+            scrollRect.movementType = ScrollRect.MovementType.Clamped;
+            scrollRect.scrollSensitivity = 30f;
+            scrollRect.inertia = false;
+
+            _vrSettingsScroll = scrollRect;
+
+            // Scrollbar lives outside Panel so RectMask2D doesn't clip it
+            GameObject scrollbarGO = new GameObject("VRScrollbar");
+            scrollbarGO.transform.SetParent(panel.parent, false);
+
+            float scrollbarWidth = 14f;
+            float panelRightEdge = panelRT.anchoredPosition.x + panelRT.sizeDelta.x / 2f;
+
+            RectTransform scrollbarRT = scrollbarGO.AddComponent<RectTransform>();
+            scrollbarRT.anchorMin = panelRT.anchorMin;
+            scrollbarRT.anchorMax = panelRT.anchorMax;
+            scrollbarRT.pivot = new Vector2(0f, 1f);
+            scrollbarRT.sizeDelta = new Vector2(scrollbarWidth, viewportHeight);
+            scrollbarRT.anchoredPosition = new Vector2(panelRightEdge, panelRT.anchoredPosition.y);
+
+            UnityEngine.UI.Image scrollbarBg = scrollbarGO.AddComponent<UnityEngine.UI.Image>();
+            scrollbarBg.color = new Color(0.1f, 0.1f, 0.1f, 0.7f);
+
+            Scrollbar scrollbar = scrollbarGO.AddComponent<Scrollbar>();
+            scrollbar.direction = Scrollbar.Direction.BottomToTop;
+
+            GameObject handleArea = new GameObject("Sliding Area");
+            handleArea.transform.SetParent(scrollbarGO.transform, false);
+            RectTransform handleAreaRT = handleArea.AddComponent<RectTransform>();
+            handleAreaRT.anchorMin = Vector2.zero;
+            handleAreaRT.anchorMax = Vector2.one;
+            handleAreaRT.offsetMin = new Vector2(2f, 10f);
+            handleAreaRT.offsetMax = new Vector2(-2f, -10f);
+
+            GameObject handle = new GameObject("Handle");
+            handle.transform.SetParent(handleArea.transform, false);
+            RectTransform handleRT = handle.AddComponent<RectTransform>();
+            handleRT.anchorMin = Vector2.zero;
+            handleRT.anchorMax = Vector2.one;
+            handleRT.sizeDelta = Vector2.zero;
+
+            UnityEngine.UI.Image handleImg = handle.AddComponent<UnityEngine.UI.Image>();
+            handleImg.color = new Color(0.55f, 0.55f, 0.55f, 1f);
+
+            scrollbar.handleRect = handleRT;
+            scrollbar.targetGraphic = handleImg;
+
+            scrollRect.verticalScrollbar = scrollbar;
+            scrollRect.verticalScrollbarVisibility = ScrollRect.ScrollbarVisibility.Permanent;
         }
 
         private static void ChangeRotationSensitivity(int sensitivity)
@@ -573,7 +636,8 @@ namespace TarkovVR.Source.Settings
             {
                 settingsUi.settingsTab_0.gameObject.active = false;
                 vrSettingsObject.active = true;
-
+                if (_vrSettingsScroll != null)
+                    _vrSettingsScroll.verticalNormalizedPosition = 1f;
             }
         }
 

--- a/Source/Settings/VRSettings.cs
+++ b/Source/Settings/VRSettings.cs
@@ -14,6 +14,7 @@ using Newtonsoft.Json;
 using static HBAO_Core;
 using EFT.UI.Ragfair;
 using TarkovVR.Patches.Visuals;
+using TarkovVR;
 using UnityEngine.UI;
 
 namespace TarkovVR.Source.Settings
@@ -46,6 +47,11 @@ namespace TarkovVR.Source.Settings
             DisableNearShadows = 1,
             IncreaseLighting = 2
         }
+            
+        // Vive Wand controller scales
+        private static readonly float[] ViveWandVaultTimeValues = [0.1f, 0.2f, 0.3f, 0.4f, 0.5f, 0.6f, 0.7f, 0.8f, 0.9f, 1.0f];
+        private static readonly float[] ViveWandCrouchThresholdValues = [0.3f, 0.4f, 0.5f, 0.6f, 0.7f, 0.8f, 0.9f];
+        
         public class ModSettings
         {
             public int rotationSensitivity { get; set; }
@@ -80,6 +86,11 @@ namespace TarkovVR.Source.Settings
             public bool disableOccCulling { get; set; }
             public bool disableFrusCulling { get; set; }
             public bool useVRKeyboard { get; set; }
+            
+            // Vive Wand controller settings
+            public float viveWandCrouchTrackpadThreshold { get; set; }
+            public float viveWandVaultHoldTime { get; set; }
+            
             public ModSettings()
             {
                 rotationSensitivity = 4;
@@ -115,6 +126,8 @@ namespace TarkovVR.Source.Settings
                 disableOccCulling = false;
                 disableFrusCulling = false;
                 useVRKeyboard = false;
+                viveWandCrouchTrackpadThreshold = 0.7f;
+                viveWandVaultHoldTime = 0.3f;
             }
             // Add more settings as needed
         }
@@ -145,6 +158,10 @@ namespace TarkovVR.Source.Settings
         private static SettingSelectSlider leftHandVerticalAngleSlider;
         private static SettingSelectSlider handPosOffsetSlider;
         private static SettingSelectSlider variableZoomSensitivitySlider;
+
+        // Vive controller settings
+        private static SettingSelectSlider viveWandCrouchThresholdSlider;
+        private static SettingSelectSlider viveWandVaultHoldTimeSlider;
 
         // Graphics Settings
         private static SettingToggle sharpenToggle;
@@ -474,6 +491,23 @@ namespace TarkovVR.Source.Settings
             useVRKeyboardToggle.Text.localizationKey = "Use In-Game VR Keyboard";
             useVRKeyboardToggle.Toggle.UpdateValue(settings.useVRKeyboard);
 
+            // Vive Wand-specific settings — only shown when Vive controllers are detected
+            if (VRGlobals.vrControllerType == "vive")
+            {
+                viveWandCrouchThresholdSlider = newSoundSettings.CreateControl(settingsUi._soundSettingsScreen._selectSliderPrefab, slidersPanel);
+                viveWandCrouchThresholdSlider.BindIndexTo(settingsUi._soundSettingsScreen.soundSettingsControllerClass.OverallVolume, new ReadOnlyCollection<float>(ViveWandCrouchThresholdValues),
+                    (x) => x.ToString("F1"));
+                viveWandCrouchThresholdSlider.Slider.action_0 = SetCrouchThreshold;
+                viveWandCrouchThresholdSlider.Text.localizationKey = "Crouch/Prone Trackpad Threshold (Vive):";
+                viveWandCrouchThresholdSlider.Slider.UpdateValue(CrouchThresholdToSlider(settings.viveWandCrouchTrackpadThreshold));
+
+                viveWandVaultHoldTimeSlider = newSoundSettings.CreateControl(settingsUi._soundSettingsScreen._selectSliderPrefab, slidersPanel);
+                viveWandVaultHoldTimeSlider.BindIndexTo(settingsUi._soundSettingsScreen.soundSettingsControllerClass.OverallVolume, new ReadOnlyCollection<float>(ViveWandVaultTimeValues),
+                    (x) => x.ToString("F1") + "s");
+                viveWandVaultHoldTimeSlider.Slider.action_0 = SetVaultHoldTime;
+                viveWandVaultHoldTimeSlider.Text.localizationKey = "Vault/Jump Hold Time (Vive):";
+                viveWandVaultHoldTimeSlider.Slider.UpdateValue(VaultHoldTimeToSlider(settings.viveWandVaultHoldTime));
+            }
 
             /*
             occCullingToggle = newSoundSettings.CreateControl(settingsUi._soundSettingsScreen._togglePrefab, slidersPanel);
@@ -1033,6 +1067,52 @@ namespace TarkovVR.Source.Settings
         private static void SetUseVRKeyboard(bool turnOn)
         {
             settings.useVRKeyboard = turnOn;
+        }
+
+        // ---- Vive Crouch Threshold ----
+        public static float GetCrouchThreshold()
+        {
+            return settings.viveWandCrouchTrackpadThreshold;
+        }
+        
+        private static int CrouchThresholdToSlider(float v)
+        {
+            int best = 0;
+            float bestDist = float.MaxValue;
+            for (int i = 0; i < ViveWandCrouchThresholdValues.Length; i++)
+            {
+                float d = Mathf.Abs(ViveWandCrouchThresholdValues[i] - v);
+                if (d < bestDist) { bestDist = d; best = i; }
+            }
+            return best;
+        }
+        private static void SetCrouchThreshold(int index)
+        {
+            if (index >= 0 && index < ViveWandCrouchThresholdValues.Length)
+                settings.viveWandCrouchTrackpadThreshold = ViveWandCrouchThresholdValues[index];
+        }
+
+        // ---- Vive Vault Hold Time ----
+        public static float GetVaultHoldTime()
+        {
+            return settings.viveWandVaultHoldTime;
+        }
+        
+        private static int VaultHoldTimeToSlider(float v)
+        {
+            int best = 0;
+            float bestDist = float.MaxValue;
+            for (int i = 0; i < ViveWandVaultTimeValues.Length; i++)
+            {
+                float d = Mathf.Abs(ViveWandVaultTimeValues[i] - v);
+                if (d < bestDist) { bestDist = d; best = i; }
+            }
+            return best;
+        }
+        private static void SetVaultHoldTime(int index)
+        {
+            if (index >= 0 && index < ViveWandVaultTimeValues.Length)
+                settings.viveWandVaultHoldTime = ViveWandVaultTimeValues[index];
         }
     }
 }


### PR DESCRIPTION
The problem: Vive Wand's jumps and vaulting were not working correctly. You had to search for a sweet spot on the trackpads to jump or vault.

What's been done:
1) Improved controller type detection algorithm
2) Added special options to the settings for Vive Wand controllers. Jumping or vaulting occurs when you click the top of the trackpad, not when you touch it
3) Added correct scrolling on the VR settings screen

Need to test:
Backward compatibility with Valve and Oculus controllers


![206639~1](https://github.com/user-attachments/assets/61079b82-d64e-46e8-8520-016603db652c)
