### PR TITLE
feat: Add controller haptic feedback on weapon fire

### DIFF
--- a/Patches/Core/Player/WeaponPatches.cs
+++ b/Patches/Core/Player/WeaponPatches.cs
@@ -1347,9 +1347,9 @@ namespace TarkovVR.Patches.Core.Player
 
         [HarmonyPostfix]
         [HarmonyPatch(typeof(FirearmController), "InitiateShot")]
-        private static void ShotHapticFeedback()
+        private static void ShotHapticFeedback(FirearmController __instance)
         {
-            if (VRGlobals.vrPlayer == null)
+            if (VRGlobals.vrPlayer == null || __instance._player != VRGlobals.player)
             {
                 return;
             }

--- a/Patches/Core/Player/WeaponPatches.cs
+++ b/Patches/Core/Player/WeaponPatches.cs
@@ -1345,7 +1345,31 @@ namespace TarkovVR.Patches.Core.Player
             }
         }
 
+        [HarmonyPostfix]
+        [HarmonyPatch(typeof(FirearmController), "InitiateShot")]
+        private static void ShotHapticFeedback()
+        {
+            if (VRGlobals.vrPlayer == null)
+            {
+                return;
+            }
 
+            bool leftHanded = VRSettings.GetLeftHandedMode();
+            (SteamVR_Input_Sources primaryHand, SteamVR_Input_Sources secondaryHand) = leftHanded
+                ? (SteamVR_Input_Sources.LeftHand, SteamVR_Input_Sources.RightHand)
+                : (SteamVR_Input_Sources.RightHand, SteamVR_Input_Sources.LeftHand);
+
+            const float frequency = 1;
+            const float duration = 0.3f;
+            const float amplitude = 1.0f;
+
+            SteamVR_Actions._default.Haptic.Execute(0, duration, frequency, amplitude, primaryHand);
+
+            if (VRGlobals.vrPlayer.isSupporting)
+            {
+                SteamVR_Actions._default.Haptic.Execute(0, duration, frequency, amplitude, secondaryHand);
+            }
+        }
     }
 }
 public static class GameObjectExtensions


### PR DESCRIPTION
Patches FirearmController.InitiateShot to trigger haptic feedback on each shot. Primary hand (dominant) always vibrates. Secondary hand vibrates only when supporting the weapon with two hands (isSupporting). Left-handed mode is respected — hand sources are swapped accordingly.