### PR TITLE
Add self-shoot damage system for VR players

### DIFF
--- a/ModSupport/FIKASupport.cs
+++ b/ModSupport/FIKASupport.cs
@@ -31,6 +31,9 @@ using TarkovVR.Patches.Core.VR;
 using System.Collections;
 using EFT.UI.Matchmaker;
 using TarkovVR.Patches.Visuals;
+using EFT.Ballistics;
+using EFT.HealthSystem;
+using EFT.InventoryLogic;
 
 
 
@@ -293,6 +296,81 @@ namespace TarkovVR.ModSupport.FIKA
             }
 
             localGameInstance.Stop(__instance.MyPlayer.ProfileId, localGameInstance.ExitStatus, exitName);
+            return false;
+        }
+
+        [HarmonyPrefix]
+        [HarmonyPatch(typeof(FikaPlayer), nameof(FikaPlayer.ApplyShot))]
+        private static bool AllowSelfDamageApplyShot(FikaPlayer __instance, ref ShotInfoClass __result,
+            DamageInfoStruct damageInfo, EBodyPart bodyPartType, EBodyPartColliderType colliderType,
+            EArmorPlateCollider armorPlateCollider, ShotIdStruct shotId)
+        {
+            if (damageInfo.Player == null || !__instance.IsYourPlayer)
+            {
+                return true;
+            }
+
+            if (damageInfo.Player.iPlayer.ProfileId != __instance.ProfileId)
+            {
+                return true;
+            }
+
+            // --- Inlined SimulatedApplyShot + Player.ApplyDamageInfo logic ---
+            ActiveHealthController healthController = __instance.ActiveHealthController;
+            if (healthController is not { IsAlive: true })
+            {
+                __result = null;
+                return false;
+            }
+
+            // Armor processing
+            bool deflected = damageInfo.DeflectedBy != null;
+            float preDamage = damageInfo.Damage;
+            List<ArmorComponent> damagedArmor =
+                __instance.ProceedDamageThroughArmor(ref damageInfo, colliderType, armorPlateCollider, true);
+            __instance.method_97(damagedArmor);
+
+            MaterialType materialType = deflected switch
+            {
+                true => MaterialType.HelmetRicochet,
+                false when damagedArmor == null || damagedArmor.Count < 1 => MaterialType.Body,
+                _ => damagedArmor[0].Material
+            };
+
+            float armorAbsorbed = preDamage - damageInfo.Damage;
+            if (armorAbsorbed > 0)
+            {
+                damageInfo.DidArmorDamage = armorAbsorbed;
+            }
+
+            // --- Inlined Player.ApplyDamageInfo (bypasses FikaPlayer friendly fire check) ---
+            __instance.LastDamagedBodyPart = bodyPartType;
+            healthController.DoWoundRelapse(damageInfo.Damage, bodyPartType);
+            __instance.LastAggressor = damageInfo.Player?.iPlayer;
+            __instance.LastDamageInfo = damageInfo;
+            __instance.LastBodyPart = bodyPartType;
+            damageInfo.BleedBlock = __instance.method_95(colliderType);
+            float bodyDamage = healthController.ApplyDamage(bodyPartType, damageInfo.Damage, damageInfo);
+            damageInfo.DidBodyDamage = bodyDamage;
+            healthController.BluntContusion(bodyPartType, 0f);
+
+            healthController.TryApplySideEffects(damageInfo, bodyPartType, out _);
+
+            __instance.ApplyHitDebuff(damageInfo.Damage, damageInfo.StaminaBurnRate * damageInfo.Damage, bodyPartType,
+                damageInfo.DamageType);
+
+            // --- Post-damage effects ---
+            __instance.ShotReactions(damageInfo, bodyPartType);
+            __instance.ReceiveDamage(damageInfo.Damage, bodyPartType, damageInfo.DamageType, armorAbsorbed,
+                materialType);
+
+            __result = new ShotInfoClass()
+            {
+                PoV = __instance.PointOfView,
+                Penetrated = damageInfo.Penetrated,
+                Material = materialType
+            };
+
             return false;
         }
     }

--- a/Patches/Core/Player/SelfShootDamagePatches.cs
+++ b/Patches/Core/Player/SelfShootDamagePatches.cs
@@ -1,0 +1,317 @@
+using System.Collections.Generic;
+using Comfort.Common;
+using EFT;
+using EFT.Ballistics;
+using EFT.InventoryLogic;
+using HarmonyLib;
+using UnityEngine;
+using static EFT.Player;
+
+namespace TarkovVR.Patches.Core.Player
+{
+    [HarmonyPatch]
+    internal class SelfShootDamagePatches
+    {
+        private const float MUZZLE_MARGIN = 0.05f;
+
+        /// <summary>
+        /// Radius of the virtual head sphere centered on the VR camera position.
+        /// Used instead of body model's head colliders which are offset from the camera in VR.
+        /// </summary>
+        private const float VR_HEAD_RADIUS = 0.12f;
+
+        [HarmonyPrefix]
+        [HarmonyPatch(typeof(EftBulletClass), nameof(EftBulletClass.IsHitIgnored))]
+        private static bool AllowSelfHitInVR(EftBulletClass __instance, ref bool __result,
+            IPlayerOwner player, RaycastHit hit, bool isFirstFragment)
+        {
+            if (player == null)
+            {
+                return true;
+            }
+
+            if (!isFirstFragment || VRGlobals.player == null ||
+                player.iPlayer.ProfileId != VRGlobals.player.ProfileId)
+            {
+                return true;
+            }
+
+            // Skip in hideout — no health controller to apply damage to.
+            if (VRGlobals.player.ActiveHealthController == null)
+            {
+                return true;
+            }
+
+            if (!player.HasBodyPartCollider(hit.collider))
+            {
+                return true;
+            }
+
+            // Head self-hits are handled exclusively via the VR camera sphere in MuzzleCheck.
+            // Ignore ballistic hits on head colliders to prevent false damage from offset body model,
+            // but stop the bullet so it doesn't fly through the head.
+            BodyPartCollider bpc = hit.collider.GetComponent<BodyPartCollider>();
+            if (bpc != null && bpc.BodyPartType == EBodyPart.Head)
+            {
+                __instance.BulletState = EftBulletClass.EBulletState.StopHit;
+                return true;
+            }
+
+            FirearmController fc = VRGlobals.firearmController;
+            if (fc != null && fc.WeaponLn > 0f)
+            {
+                Vector3 gunBase = fc.GunBaseTransform.position;
+                Vector3 muzzle = fc.CurrentFireport.position;
+                Vector3 barrelDir = (muzzle - gunBase).normalized;
+                float checkLength = fc.WeaponLn - MUZZLE_MARGIN;
+
+                if (checkLength > 0f)
+                {
+                    Ray barrelRay = new(gunBase, barrelDir);
+                    if (hit.collider.Raycast(barrelRay, out _, checkLength))
+                    {
+                        // Barrel intersects body collider — weapon pushed through body, ignore
+                        return true;
+                    }
+
+                    // Raycast missed — gunBase may be inside the collider (ray from inside
+                    // doesn't detect the collider in Unity). Check with ClosestPoint.
+                    Vector3 closestToBase = hit.collider.ClosestPoint(gunBase);
+                    if ((closestToBase - gunBase).sqrMagnitude < 0.0001f)
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            __result = false;
+            return false;
+        }
+
+        [HarmonyPostfix]
+        [HarmonyPatch(typeof(FirearmController), nameof(FirearmController.method_58))]
+        private static void MuzzleHeadDamageCheck(FirearmController __instance, AmmoItemClass ammo)
+        {
+            EFT.Player player = VRGlobals.player;
+            if (player == null || !__instance._player.IsYourPlayer)
+            {
+                return;
+            }
+
+            // Skip in hideout — no health controller to apply damage to.
+            if (player.ActiveHealthController == null)
+            {
+                return;
+            }
+
+            if (__instance._player.ProfileId != player.ProfileId)
+            {
+                return;
+            }
+
+            Camera vrCam = VRGlobals.VRCam;
+            if (vrCam == null)
+            {
+                return;
+            }
+
+            Vector3 muzzle = __instance.CurrentFireport.position;
+            Vector3 gunBase = __instance.GunBaseTransform.position;
+            Vector3 barrelDir = (muzzle - gunBase).normalized;
+
+            // Offset from eye position (camera) to approximate head center:
+            // ~8cm back from the eyes along the camera's forward axis.
+            Vector3 headCenter = vrCam.transform.position - vrCam.transform.forward * 0.08f;
+            float distToHead = Vector3.Distance(muzzle, headCenter);
+
+            Vector3 toHead = (headCenter - muzzle).normalized;
+            float aimDot = Vector3.Dot(barrelDir, toHead);
+
+            bool headHit = false;
+            if (distToHead < VR_HEAD_RADIUS)
+            {
+                // Muzzle inside head sphere — require barrel aimed at head center
+                headHit = aimDot > 0.5f;
+            }
+            else if (RaySphereIntersect(muzzle, barrelDir, headCenter, VR_HEAD_RADIUS))
+            {
+                headHit = true;
+            }
+
+            if (!headHit)
+            {
+                return;
+            }
+
+            BodyPartCollider[] hitColliders = player._hitColliders;
+            if (hitColliders == null)
+            {
+                return;
+            }
+
+            // Determine head zone by projecting bullet direction onto VR camera orientation.
+            EBodyPartColliderType zone = GetHeadZoneFromDirection(barrelDir, vrCam.transform);
+
+            BodyPartCollider headCollider = null;
+            BodyPartCollider fallback = null;
+            foreach (BodyPartCollider bodyPartCollider in hitColliders)
+            {
+                if (bodyPartCollider.BodyPartColliderType == zone)
+                {
+                    headCollider = bodyPartCollider;
+                    break;
+                }
+
+                if (bodyPartCollider.BodyPartColliderType == EBodyPartColliderType.HeadCommon)
+                {
+                    fallback = bodyPartCollider;
+                }
+            }
+
+            headCollider ??= fallback;
+
+            if (headCollider == null)
+            {
+                return;
+            }
+
+            IPlayerOwner playerOwner =
+                Singleton<GameWorld>.Instance.GetEverExistedBridgeByProfileID(player.ProfileId);
+            if (playerOwner == null)
+            {
+                return;
+            }
+
+            // Simulate ricochet and penetration checks, matching vanilla SetShotStatus flow.
+            // Without this, ProceedDamageThroughArmor treats every hit as full penetration.
+            MongoID? blockedBy = null;
+            MongoID? deflectedBy = null;
+            List<ArmorComponent> armors = [];
+            player.Inventory.GetPutOnArmorsNonAlloc(armors);
+
+            // Compute hit normal on VR head sphere for ricochet angle calculation.
+            Vector3 sphereHitNormal = (muzzle - headCenter).normalized;
+
+            foreach (ArmorComponent armor in armors)
+            {
+                if (!armor.ShotMatches(headCollider.BodyPartColliderType, (EArmorPlateCollider)0))
+                    continue;
+                if (armor.Repairable.Durability <= 0f)
+                    continue;
+
+                // Ricochet check (same logic as ArmorComponent.Deflects / SetShotStatus)
+                Vector3 ricochetVals = armor.Template.RicochetVals;
+                if (ricochetVals.x > 0f)
+                {
+                    float angle = Vector3.Angle(-barrelDir, sphereHitNormal);
+                    if (angle > ricochetVals.z)
+                    {
+                        float t = Mathf.InverseLerp(90f, ricochetVals.z, angle);
+                        float ricochetChance = Mathf.Lerp(ricochetVals.x, ricochetVals.y, t);
+                        if (Random.value < ricochetChance)
+                        {
+                            deflectedBy = armor.Item.Id;
+                            break;
+                        }
+                    }
+                }
+
+                // Penetration check
+                float penPower = ammo.PenetrationPower;
+                ArmorResistanceStruct resist = GClass659.RealResistance(
+                    armor.Repairable.Durability, armor.Repairable.TemplateDurability,
+                    armor.ArmorClass, penPower);
+                float penChance = resist.GetPenetrationChance(penPower);
+
+                if (Random.value * 100f > penChance)
+                {
+                    blockedBy = armor.Item.Id;
+                }
+                break;
+            }
+
+            DamageInfoStruct damageInfo = new()
+            {
+                DamageType = EDamageType.Bullet,
+                Damage = ammo.Damage,
+                PenetrationPower = ammo.PenetrationPower,
+                ArmorDamage = ammo.ArmorDamagePortion,
+                BlockedBy = blockedBy,
+                DeflectedBy = deflectedBy,
+                Direction = barrelDir,
+                HitPoint = muzzle,
+                HitNormal = sphereHitNormal,
+                MasterOrigin = gunBase,
+                HittedBallisticCollider = headCollider,
+                Player = playerOwner,
+                Weapon = __instance.Item,
+                IsForwardHit = true,
+                StaminaBurnRate = ammo.StaminaBurnRate,
+                HeavyBleedingDelta = ammo.HeavyBleedingDelta,
+                LightBleedingDelta = ammo.LightBleedingDelta,
+                SourceId = ammo.TemplateId
+            };
+
+            float hpBefore = player.ActiveHealthController.GetBodyPartHealth(EBodyPart.Head).Current;
+
+            ShotInfoClass shotInfo = player.ApplyShot(damageInfo, headCollider.BodyPartType, headCollider.BodyPartColliderType,
+                (EArmorPlateCollider)0, ShotIdStruct.EMPTY_SHOT_ID);
+
+            float hpAfter = player.ActiveHealthController.GetBodyPartHealth(EBodyPart.Head).Current;
+            float absorbed = ammo.Damage - (hpBefore - hpAfter);
+
+            // ApplyShot always passes absorbed=0 to ApplyDamageInfo, so BluntContusion
+            // never triggers from bullets. Apply contusion on any armored head hit.
+            if (shotInfo != null && shotInfo.Material != MaterialType.Body && absorbed > 0f)
+            {
+                player.ActiveHealthController.DoContusion(30f, 0.5f);
+            }
+        }
+
+        /// <summary>
+        /// Maps bullet direction to a head zone using VR camera orientation.
+        /// The impact normal (-barrelDir) in camera-local space tells us which part of the head is hit:
+        /// camera forward = face, camera up = top of head, camera right = right ear.
+        /// </summary>
+        private static EBodyPartColliderType GetHeadZoneFromDirection(Vector3 barrelDir, Transform camTransform)
+        {
+            // Impact direction in camera-local space: where on the head the bullet lands
+            Vector3 local = camTransform.InverseTransformDirection(-barrelDir);
+            float fwd = local.z;   // positive = hits face, negative = hits back of head
+            float up = local.y;    // positive = hits top, negative = hits bottom/neck
+            float side = Mathf.Abs(local.x);
+
+            // NeckFront/NeckBack are not EBodyPart.Head — they're handled by ballistics
+            // with their own armor checks, so we only map to actual head zones here.
+            if (up > 0.7f) return EBodyPartColliderType.ParietalHead;
+            if (side > 0.7f) return EBodyPartColliderType.Ears;
+            if (fwd < -0.3f) return EBodyPartColliderType.BackHead;
+            if (up < -0.2f) return EBodyPartColliderType.Jaw;
+            if (up < 0.3f) return EBodyPartColliderType.Eyes;
+
+            return EBodyPartColliderType.HeadCommon;
+        }
+
+        private static bool RaySphereIntersect(Vector3 origin, Vector3 dir, Vector3 center,
+            float radius)
+        {
+            Vector3 oc = origin - center;
+            float b = Vector3.Dot(oc, dir);
+            float c = oc.sqrMagnitude - radius * radius;
+
+            if (c <= 0f)
+            {
+                return true;
+            }
+
+            float discriminant = b * b - c;
+            if (discriminant < 0f)
+            {
+                return false;
+            }
+
+            float t = -b - Mathf.Sqrt(discriminant);
+            return !(t < 0f);
+        }
+    }
+}


### PR DESCRIPTION
Self-Shoot Damage System for VR
Full self-damage system when shooting yourself in VR.

Body damage

- Patch on EftBulletClass.IsHitIgnored allows bullets to hit player's own body colliders when the muzzle extends past the body (but not when barrel clips through the model)
- Barrel ray + ClosestPoint inside-collider detection

Head damage

- Virtual sphere (12cm radius) around VR camera position replaces offset body model head colliders
- Head zone projection (parietal, ears, back, jaw, eyes) via VR camera local coordinates
- Bullet stops on head hit (BulletState = StopHit)

Armor & ballistics

- Vanilla penetration check simulation (RealResistance + GetPenetrationChance) with BlockedBy
- Ricochet via vanilla logic (RicochetVals + DeflectedBy) with half damage
- Correct ArmorDamagePortion usage instead of raw ArmorDamage int
- Contusion effect (30s) on armored head hits